### PR TITLE
Add PyQt GUI scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # SkyFall
-Skyfall is an application for team based UAV wifi geolocation and mapping.
+
+SkyFall is a tactical GUI interface for white-hat UAV reconnaissance. It visualizes
+UAV locations and detected wireless targets on an interactive map.
+
+## Requirements
+* Python 3.8+
+* PyQt5 and PyQtWebEngine
+
+## Running
+Install dependencies and run the GUI:
+
+```bash
+pip install PyQt5 PyQtWebEngine
+python gui/main.py
+```
+
+The application loads example data from `sample_data.json` and plots the nodes
+and targets on a Leaflet-based map.
+
+To bundle as a single executable you can use PyInstaller:
+
+```bash
+pip install pyinstaller
+pyinstaller gui/main.py --onefile --noconsole
+```
+
+## Files
+- `gui/main.py` – main PyQt GUI application.
+- `gui/map.html` – embedded Leaflet map used by the GUI.
+- `sample_data.json` – example mesh packet data.

--- a/gui/main.py
+++ b/gui/main.py
@@ -1,0 +1,114 @@
+import json
+import os
+import sys
+from PyQt5 import QtCore, QtWidgets, QtGui, QtWebEngineWidgets
+
+DATA_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'sample_data.json')
+MAP_HTML = os.path.join(os.path.dirname(__file__), 'map.html')
+
+
+def load_data(path=DATA_FILE):
+    if os.path.exists(path):
+        with open(path) as f:
+            return json.load(f)
+    return []
+
+
+def discover_hardware():
+    wifi = []
+    gps = []
+    for root, dirs, files in os.walk('/sys/class/net'):
+        for d in dirs:
+            if d.startswith('wlan') or d.startswith('wifi'):
+                wifi.append(d)
+    if os.path.exists('/dev'):
+        for f in os.listdir('/dev'):
+            if 'gps' in f.lower() or f.startswith('ttyUSB'):
+                gps.append(f)
+    return {'wifi': wifi, 'gps': gps}
+
+
+n_dark = QtGui.QColor('#2b2b2b')
+
+class MapView(QtWebEngineWidgets.QWebEngineView):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setContextMenuPolicy(QtCore.Qt.NoContextMenu)
+        self.load(QtCore.QUrl.fromLocalFile(MAP_HTML))
+
+    def add_marker(self, lat, lon, info):
+        js = f"addMarker({lat}, {lon}, '{info}')"
+        self.page().runJavaScript(js)
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle('SkyFall GUI')
+        self.resize(1200, 800)
+        self.setStyleSheet('background-color: #121212; color: #fff;')
+
+        self.sidebar = QtWidgets.QFrame()
+        self.sidebar.setFixedWidth(250)
+        self.sidebar.setStyleSheet('background-color: #1e1e1e;')
+        side_layout = QtWidgets.QVBoxLayout(self.sidebar)
+        side_layout.addWidget(QtWidgets.QLabel('Filters / Stats'))
+        self.hw_label = QtWidgets.QLabel('Hardware:')
+        side_layout.addWidget(self.hw_label)
+        side_layout.addStretch(1)
+
+        self.map_view = MapView()
+
+        self.bottom = QtWidgets.QFrame()
+        self.bottom.setFixedHeight(150)
+        self.bottom.setStyleSheet('background-color: #1e1e1e;')
+        bottom_layout = QtWidgets.QVBoxLayout(self.bottom)
+        self.target_info = QtWidgets.QLabel('Target info')
+        bottom_layout.addWidget(self.target_info)
+
+        central = QtWidgets.QWidget()
+        main_layout = QtWidgets.QHBoxLayout(central)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+        main_layout.addWidget(self.sidebar)
+
+        map_container = QtWidgets.QVBoxLayout()
+        map_container.addWidget(self.map_view)
+        map_container.addWidget(self.bottom)
+        main_layout.addLayout(map_container)
+        self.setCentralWidget(central)
+
+        self.status = QtWidgets.QStatusBar()
+        self.setStatusBar(self.status)
+        self.update_status()
+        self.timer = QtCore.QTimer()
+        self.timer.timeout.connect(self.update_status)
+        self.timer.start(5000)
+
+        self.load_markers()
+
+    def update_status(self):
+        hw = discover_hardware()
+        self.hw_label.setText(f"Hardware: wifi={len(hw['wifi'])} gps={len(hw['gps'])}")
+        self.status.showMessage('Mesh Active | Nodes Online: 2 | Packets/sec: 0 | Time: ' +
+                                QtCore.QDateTime.currentDateTime().toString())
+
+    def load_markers(self):
+        data = load_data()
+        for node in data:
+            gps = node['gps']
+            info = f"Node {node['node_id']}"
+            self.map_view.add_marker(gps['lat'], gps['lon'], info)
+            for t in node.get('targets', []):
+                info = f"Target {t['mac']} RSSI {t['rssi']}"
+                self.map_view.add_marker(gps['lat'] + 0.0005, gps['lon'] + 0.0005, info)
+
+
+def main():
+    app = QtWidgets.QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == '__main__':
+    main()

--- a/gui/map.html
+++ b/gui/map.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>SkyFall Map</title>
+<style>
+  html, body, #map { height: 100%; margin: 0; background: #222; color: #eee; }
+</style>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+</head>
+<body>
+<div id="map"></div>
+<script>
+var map = L.map('map').setView([38.8951, -77.0364], 13);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  maxZoom: 19,
+}).addTo(map);
+
+function addMarker(lat, lon, info) {
+  var marker = L.marker([lat, lon]).addTo(map);
+  if(info) marker.bindPopup(info);
+}
+</script>
+</body>
+</html>

--- a/sample_data.json
+++ b/sample_data.json
@@ -1,0 +1,26 @@
+[
+  {
+    "node_id": "uav-01",
+    "gps": { "lat": 38.8951, "lon": -77.0364 },
+    "targets": [
+      {
+        "mac": "DE:AD:BE:EF:00:01",
+        "rssi": -62,
+        "freq": 2412,
+        "timestamp": 1723588200
+      }
+    ]
+  },
+  {
+    "node_id": "uav-02",
+    "gps": { "lat": 38.8960, "lon": -77.0370 },
+    "targets": [
+      {
+        "mac": "DE:AD:BE:EF:00:02",
+        "rssi": -70,
+        "freq": 2412,
+        "timestamp": 1723588205
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- create a PyQt-based GUI skeleton with sidebar, status bar, map view, and bottom panel
- embed a Leaflet map and simple marker function
- add example JSON data and hardware discovery helpers
- document setup and packaging in README

## Testing
- `pip install PyQt5 PyQtWebEngine`
- `QTWEBENGINE_CHROMIUM_FLAGS="--no-sandbox" QT_QPA_PLATFORM=offscreen python gui/main.py` *(fails: OpenGL context creation failed)*

------
https://chatgpt.com/codex/tasks/task_e_688806c5d92883259aa59a97ebb582ec