### PR TITLE
Add hardware selection feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ python gui/main.py
 The application loads example data from `sample_data.json` and plots the nodes
 and targets on a Leaflet-based map.
 
+Use the **Select Hardware** button in the sidebar to choose which WiFi
+interface and GPS device will be used for surveys. Hardware discovery is
+supported on both Windows and Linux.
+
 To bundle as a single executable you can use PyInstaller:
 
 ```bash


### PR DESCRIPTION
## Summary
- add cross-platform hardware discovery for Windows and Linux
- provide dialog in the GUI to choose WiFi and GPS hardware
- document hardware selection in README

## Testing
- `python -m py_compile gui/main.py`
- *(fails: `python gui/main.py` due to missing PyQt5)*

------
https://chatgpt.com/codex/tasks/task_e_6888094afb8c8325b72f0afd9953c45b