### PR TITLE
Add cross-platform hardware discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ and placing your selected interface into monitor mode. You can choose the
 desired channel, SSID and encryption method before starting packet
 capture via aircrack-ng utilities.
 
+You can also run `hardware.py` directly from the command line to list
+available WiFi interfaces and GPS devices detected on your system.
+
 To bundle as a single executable you can use PyInstaller:
 
 ```bash
@@ -42,3 +45,4 @@ pyinstaller gui/main.py --onefile --noconsole
 - `gui/map.html` – embedded Leaflet map used by the GUI.
 - `sample_data.json` – example mesh packet data.
 - `wifi.py` – helper functions for WiFi scanning and monitor mode.
+- `hardware.py` – cross-platform discovery of WiFi interfaces and GPS devices.

--- a/gui/main.py
+++ b/gui/main.py
@@ -10,6 +10,7 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from wifi import scan_networks, start_monitor_mode, stop_monitor_mode
+from hardware import discover_hardware
 
 DATA_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'sample_data.json')
 MAP_HTML = os.path.join(os.path.dirname(__file__), 'map.html')
@@ -20,48 +21,6 @@ def load_data(path=DATA_FILE):
         with open(path) as f:
             return json.load(f)
     return []
-
-
-def discover_hardware():
-    """Return available WiFi interfaces and GPS devices."""
-    wifi = []
-    gps = []
-
-    if sys.platform.startswith('linux'):
-        for root, dirs, _ in os.walk('/sys/class/net'):
-            for d in dirs:
-                if d.startswith('wlan') or d.startswith('wifi'):
-                    wifi.append(d)
-        if os.path.exists('/dev'):
-            for f in os.listdir('/dev'):
-                lf = f.lower()
-                if 'gps' in lf or f.startswith('ttyUSB'):
-                    gps.append(f)
-
-    elif sys.platform.startswith('win'):
-        try:
-            out = subprocess.check_output(
-                ['netsh', 'wlan', 'show', 'interfaces'],
-                text=True, stderr=subprocess.DEVNULL)
-            for line in out.splitlines():
-                if 'Name' in line:
-                    wifi.append(line.split(':', 1)[1].strip())
-        except Exception:
-            pass
-
-        try:
-            out = subprocess.check_output(
-                ['wmic', 'path', 'Win32_SerialPort', 'get', 'DeviceID,Name'],
-                text=True, stderr=subprocess.DEVNULL)
-            for line in out.splitlines():
-                if 'GPS' in line.upper():
-                    parts = line.split()
-                    if parts:
-                        gps.append(parts[0])
-        except Exception:
-            pass
-
-    return {'wifi': wifi, 'gps': gps}
 
 
 n_dark = QtGui.QColor('#2b2b2b')

--- a/hardware.py
+++ b/hardware.py
@@ -1,0 +1,85 @@
+import os
+import sys
+import subprocess
+from typing import Dict, List
+
+
+def list_wifi_interfaces() -> List[str]:
+    """Return available WiFi interfaces on the current system."""
+    wifi = []
+    if sys.platform.startswith("linux"):
+        # Try using iw to list wireless interfaces
+        try:
+            output = subprocess.check_output(["iw", "dev"], text=True, stderr=subprocess.DEVNULL)
+            for line in output.splitlines():
+                line = line.strip()
+                if line.startswith("Interface"):
+                    wifi.append(line.split()[1])
+        except Exception:
+            pass
+        # Fall back to checking /sys/class/net
+        if not wifi:
+            try:
+                for iface in os.listdir("/sys/class/net"):
+                    if iface.startswith(("wlan", "wifi", "wl", "ath", "wlp")):
+                        wifi.append(iface)
+            except Exception:
+                pass
+    elif sys.platform.startswith("win"):
+        try:
+            out = subprocess.check_output(
+                ["netsh", "wlan", "show", "interfaces"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+            for line in out.splitlines():
+                if "Name" in line:
+                    wifi.append(line.split(":", 1)[1].strip())
+        except Exception:
+            pass
+    return wifi
+
+
+def list_gps_devices() -> List[str]:
+    """Return available GPS devices on the current system."""
+    gps = []
+    if sys.platform.startswith("linux"):
+        try:
+            for dev in os.listdir("/dev"):
+                lower = dev.lower()
+                if lower.startswith(("ttyusb", "ttyacm")) or "gps" in lower:
+                    gps.append(os.path.join("/dev", dev))
+        except Exception:
+            pass
+    elif sys.platform.startswith("win"):
+        try:
+            out = subprocess.check_output(
+                ["wmic", "path", "Win32_SerialPort", "get", "DeviceID,Name"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+            for line in out.splitlines():
+                if not line.strip():
+                    continue
+                if "COM" in line:
+                    if "GPS" in line.upper() or "GNSS" in line.upper():
+                        device = line.split()[0]
+                        gps.append(device)
+        except Exception:
+            pass
+    return gps
+
+
+def discover_hardware() -> Dict[str, List[str]]:
+    """Return a dictionary with lists of WiFi interfaces and GPS devices."""
+    return {"wifi": list_wifi_interfaces(), "gps": list_gps_devices()}
+
+
+if __name__ == "__main__":
+    hw = discover_hardware()
+    print("WiFi interfaces:")
+    for iface in hw["wifi"]:
+        print(f"  {iface}")
+    print("GPS devices:")
+    for dev in hw["gps"]:
+        print(f"  {dev}")


### PR DESCRIPTION
## Summary
- add a dedicated `hardware.py` module to detect WiFi and GPS hardware on Windows and Linux
- integrate new discovery module into the GUI
- document new tool and list it in project files

## Testing
- `python -m py_compile hardware.py gui/main.py wifi.py`
- `python hardware.py`

------
https://chatgpt.com/codex/tasks/task_e_68881a72b8b483258971da56c25041ea